### PR TITLE
Update wrangler.toml

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,6 +1,6 @@
 #:schema node_modules/wrangler/config-schema.json
 name = "bolt"
-compatibility_flags = ["nodejs_compat"]
-compatibility_date = "2024-07-01"
+compatibility_flags = [ "nodejs_compat" ]
+compatibility_date = "2024-09-23"
 pages_build_output_dir = "./build/client"
 send_metrics = false


### PR DESCRIPTION
FIX cloudflare deployment  ERROR:

To enable built-in Node.js APIs and add polyfills, you need to add the nodejs_compat compatibility flag to your wrangler configuration. This also enables nodejs_compat_v2 as long as your compatibility date is 2024-09-23 or later. [Learn more about the Node.js compatibility flag and v2](https://developers.cloudflare.com/workers/configuration/compatibility-flags/#nodejs-compatibility-flag).